### PR TITLE
Add tslib@^2.0.0 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,6 @@
         "webpack-cli": "^3.3.4"
     },
     "dependencies": {
+        "tslib": "^2.0.0"
     }
 }


### PR DESCRIPTION
The extension didn't work in my Neovim until I have manually added the **tslib** dependency.

`Error on createExtension coc-phpactor from ~/.config/coc/extensions/node_modules/coc-phpactor/lib/extension.js Error: Cannot find module 'tslib'.`